### PR TITLE
refactor: unify engines

### DIFF
--- a/dpdk/src/eal.rs
+++ b/dpdk/src/eal.rs
@@ -102,6 +102,8 @@ impl Drop for EalLoggingContext {
     }
 }
 
+unsafe impl Send for EalLoggingContext {}
+
 #[derive(Debug)]
 pub struct Eal {
     _ctx: Option<EalLoggingContext>,

--- a/dwd/src/engine.rs
+++ b/dwd/src/engine.rs
@@ -166,16 +166,12 @@ impl Runtime {
         let stat = engine.stats();
         let limits = engine.pps_limits();
 
-        let (cv, rx) = std::sync::mpsc::sync_channel(1);
-
         let engine = {
             let is_running = self.is_running.clone();
             Builder::new()
                 .name("engine".into())
-                .spawn(move || engine.run(is_running, cv))?
+                .spawn(move || engine.run(is_running))?
         };
-
-        let _ = rx.recv()?;
 
         let (tx, rx) = mpsc::channel(1);
 


### PR DESCRIPTION
Now each engine has the same (almost) building sequence. Making UI generic is the next move.