### PR TITLE
chore: bootstrap dwd-core criterion benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +207,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +229,12 @@ name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "castaway"
@@ -250,6 +268,33 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "circular"
@@ -329,6 +374,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +455,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "darling"
@@ -435,6 +544,7 @@ dependencies = [
  "anyhow",
  "axum",
  "bytes",
+ "criterion",
  "dwd-dpdk",
  "dwd-proto",
  "etherparse",
@@ -675,6 +785,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +997,17 @@ checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
 dependencies = [
  "jemalloc-sys",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1087,10 +1219,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "overload"
@@ -1186,6 +1333,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "pnet"
@@ -1542,6 +1717,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,6 +1826,15 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1897,6 +2101,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2172,6 +2386,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,6 +2420,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,6 +2489,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/dwd-core/Cargo.toml
+++ b/dwd-core/Cargo.toml
@@ -54,3 +54,18 @@ netlink-sys = { version = "0.8" }
 
 [features]
 dpdk = ["dep:dpdk", "dep:thiserror", "dep:pcap-parser", "dep:etherparse"]
+
+[dev-dependencies]
+criterion = "0.7"
+
+[[bench]]
+name = "shaper"
+harness = false
+
+[[bench]]
+name = "generator"
+harness = false
+
+[[bench]]
+name = "histogram"
+harness = false

--- a/dwd-core/benches/generator.rs
+++ b/dwd-core/benches/generator.rs
@@ -1,0 +1,55 @@
+//! Benchmarks for the RPS lookup hot path: [`Generator::current_at`].
+//!
+//! `run_generator` polls the active generator every 10ms, but the lookup math
+//! itself is the inner-loop-adjacent cost we care about. We bench the concrete
+//! `LineGenerator` (covers `const`, which is a degenerate line) and
+//! `SinGenerator` (the interesting phase/`sin` math).
+//!
+//! Time is pinned: we `activate_at(base)` once at setup and call
+//! `current_at(base + offset)` with a fixed offset so no `Instant::now()` is
+//! read inside the measured closure. The offset sits well inside the
+//! generator's duration so `current_at` returns `Some(..)` (the live branch).
+
+use std::{
+    hint::black_box,
+    time::{Duration, Instant},
+};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use dwd_core::generator::{Generator, LineGenerator, SinGenerator};
+
+fn bench_generator(c: &mut Criterion) {
+    let mut group = c.benchmark_group("generator");
+
+    let base = Instant::now();
+    // Fixed query point, half-way through a 100s generation window.
+    let at = base + Duration::from_secs(50);
+
+    // Constant: a line with equal endpoints.
+    group.bench_function("const_current_at", |b| {
+        let mut g = LineGenerator::new(1_000, 1_000, Duration::from_secs(100));
+        g.activate_at(base);
+        b.iter(|| black_box(g.current_at(black_box(at))));
+    });
+
+    // Ramping line: distinct endpoints exercise the slope arithmetic.
+    group.bench_function("line_current_at", |b| {
+        let mut g = LineGenerator::new(1_000, 1_000_000, Duration::from_secs(100));
+        g.activate_at(base);
+        b.iter(|| black_box(g.current_at(black_box(at))));
+    });
+
+    // Sin: midpoint + amplitude * sin(k * t + phase). The transcendental sin
+    // call dominates and is the reason this path is benched separately.
+    group.bench_function("sin_current_at", |b| {
+        // pps_mid = 500_500, a = 499_500, one radian/sec, zero phase.
+        let mut g = SinGenerator::new(500_500.0, 499_500.0, 1.0, 0.0, Duration::from_secs(100));
+        g.activate_at(base);
+        b.iter(|| black_box(g.current_at(black_box(at))));
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_generator);
+criterion_main!(benches);

--- a/dwd-core/benches/histogram.rs
+++ b/dwd-core/benches/histogram.rs
@@ -1,0 +1,53 @@
+//! Benchmarks for log-bucketed latency: [`PerCpuLogHistogram::record`] (the
+//! per-request write side) and [`LogHistogram::quantile`] (the read side used
+//! by the TUI / metrics).
+//!
+//! `record(us)` computes `log_FACTOR(us)`, clamps to the bucket count, and
+//! bumps a counter — one `log()` call per request. We feed a fixed, cycling
+//! set of microsecond values (set up outside the loop) so the measured work is
+//! deterministic and allocation-free.
+//!
+//! `quantile(q)` scans the snapshot and interpolates. We build a realistic
+//! filled snapshot once and query a few representative quantiles.
+
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use dwd_core::histogram::{LogHistogram, PerCpuLogHistogram};
+
+fn bench_histogram(c: &mut Criterion) {
+    let mut group = c.benchmark_group("histogram");
+
+    // Representative latency samples in microseconds spanning the bucket range
+    // (sub-microsecond up to multi-second). Precomputed, no allocation in loop.
+    let samples: [u64; 8] = [1, 10, 100, 1_000, 5_000, 50_000, 500_000, 5_000_000];
+
+    group.bench_function("record", |b| {
+        let hist = PerCpuLogHistogram::default();
+        let mut i = 0usize;
+        b.iter(|| {
+            // Cycle through the fixed samples branchlessly via masking-free mod;
+            // the index update is cheap relative to the log() in record().
+            let us = samples[i % samples.len()];
+            hist.record(black_box(us));
+            i = i.wrapping_add(1);
+        });
+    });
+
+    // Build a filled snapshot once: distribute counts across the buckets so
+    // quantile() walks a realistic distribution rather than a single spike.
+    let n_buckets = PerCpuLogHistogram::default().buckets().len();
+    let snapshot: Vec<u64> = (0..n_buckets).map(|i| (i as u64 % 7) + 1).collect();
+    let hist = LogHistogram::new(snapshot);
+
+    for &q in &[0.5_f64, 0.9, 0.99, 0.999] {
+        group.bench_function(format!("quantile_p{}", (q * 1000.0) as u64), |b| {
+            b.iter(|| black_box(hist.quantile(black_box(q))));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_histogram);
+criterion_main!(benches);

--- a/dwd-core/benches/shaper.rs
+++ b/dwd-core/benches/shaper.rs
@@ -1,0 +1,56 @@
+//! Benchmarks for the token-bucket [`Shaper`] — the rate limiter every engine
+//! drives once per worker loop tick.
+//!
+//! The hot pattern in a worker is `tick()` (mint tokens from elapsed time) →
+//! execute up to N tasks → `consume(n)` (debit). We bench `tick`, `consume`,
+//! and the combined `tick + consume` cycle.
+//!
+//! `Shaper::tick()` reads `Instant::now()` internally, so the measured closure
+//! includes one clock read per call (intrinsic to the function under test).
+//! `consume()` is pure arithmetic and is benched in isolation.
+
+use std::{
+    hint::black_box,
+    sync::{atomic::AtomicU64, Arc},
+};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use dwd_core::shaper::Shaper;
+
+fn bench_shaper(c: &mut Criterion) {
+    let mut group = c.benchmark_group("shaper");
+
+    // tick() in isolation: mints tokens from the elapsed wall-clock time and
+    // returns the number available. Includes one Instant::now() read.
+    group.bench_function("tick", |b| {
+        let limit = Arc::new(AtomicU64::new(1_000_000));
+        let mut shaper = Shaper::new(black_box(1), limit);
+        b.iter(|| black_box(shaper.tick()));
+    });
+
+    // consume() in isolation: pure floating-point debit, no clock read.
+    // The internal token count is an f64 that simply drifts negative over the
+    // loop; consume() never branches on it, so the work per call is constant
+    // and underflow is harmless (no panic, no behavior change).
+    group.bench_function("consume", |b| {
+        let limit = Arc::new(AtomicU64::new(1_000_000));
+        let mut shaper = Shaper::new(1, limit);
+        b.iter(|| shaper.consume(black_box(1)));
+    });
+
+    // The realistic worker cycle: tick then consume what we got. Burst size 1
+    // keeps tick() returning a positive token count for steady-state behavior.
+    group.bench_function("tick_consume", |b| {
+        let limit = Arc::new(AtomicU64::new(1_000_000));
+        let mut shaper = Shaper::new(1, limit);
+        b.iter(|| {
+            let n = black_box(shaper.tick());
+            shaper.consume(black_box(n));
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_shaper);
+criterion_main!(benches);


### PR DESCRIPTION
Add the project's first benchmark infrastructure. The suite was at near-zero and there was no way to measure hot-path changes against a baseline, which the performance contract requires.

## What

- Add `criterion` as a `dwd-core` dev-dependency and three `harness = false` bench targets.
- **shaper** — `Shaper::tick` / `consume` / combined worker cycle.
- **generator** — `const`, `line` and `sin` `current_at` (time pinned at setup so no `Instant::now()` runs inside the measured closure; the offset stays inside the duration window to exercise the live `Some(..)` branch).
- **histogram** — `record` and `quantile` at p50/p90/p99/p99.9.

Inputs are built outside `b.iter` and passed through `black_box` so the optimizer cannot elide the work.

## Why

No hot-path code is changed — this only establishes baselines so future perf work can show before/after numbers, as the performance contract demands.

## Baselines (quick pass, median)

- shaper: `tick` ~58.6 ns (dominated by the internal `Instant::now()`), `consume` ~1.6 ns
- generator: `const`/`line` ~13 ns, `sin` ~59 ns (`f64::sin` dominates)
- histogram: `record` ~15.6 ns, `quantile` ~73-103 ns

Local gate green (fmt / clippy `dwd` + `dwd-core` / check / test / release build). DPDK tx loop not benched — feature-gated and unverifiable without NIC hardware.