### PR TITLE
feat: add HTTPS (TLS) support to the http engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,12 +580,14 @@ dependencies = [
  "prometheus-client",
  "quinn",
  "rand",
+ "rcgen",
  "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
  "thiserror 2.0.6",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tonic",
 ]
@@ -1285,6 +1293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,6 +1363,16 @@ dependencies = [
  "circular",
  "nom",
  "rusticata-macros",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -1518,6 +1542,12 @@ dependencies = [
  "pnet_packet",
  "pnet_sys",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1856,6 +1886,19 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -2287,6 +2330,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2335,6 +2397,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2904,6 +2976,15 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "zerocopy"

--- a/README.md
+++ b/README.md
@@ -113,6 +113,17 @@ There is a possibility of bursts (grouping requests/packets into a bunch and sen
 
 If the `--requests-per-socket=N` option is specified, then every `N` requests the socket is recreated. The port is selected from free ones by the operating system.
 
+### HTTPS
+
+The `http` mode can speak HTTPS by passing `--tls`; every connection then performs a TLS handshake before the HTTP/1 exchange. Since load testing usually targets staging hosts and bare IPs, **certificate verification is disabled** — any presented certificate is accepted. Use `--server-name <NAME>` to set the TLS SNI hostname the server may route on; when omitted, the target IP is used and the (hostname-only) SNI extension is suppressed.
+
+```bash
+dwd http 127.0.0.1:443 --tls --payload-json ammo.jsonl
+dwd http 127.0.0.1:443 --tls --server-name example.org --payload-json ammo.jsonl
+```
+
+TLS is not supported by the restricted `http/raw` mode (passing `--tls` there is an error). The `http3` mode is always over TLS, as QUIC mandates it.
+
 ## DPDK mode
 
 In this mode, there is no kernel network stack - all packet preparation and processing occurs in user space by separating the network card from the kernel, with very careful tuning of the hardware on which the DWD is launched.

--- a/dwd-core/Cargo.toml
+++ b/dwd-core/Cargo.toml
@@ -38,6 +38,12 @@ quinn = { version = "0.11", default-features = false, features = [
     "rustls-ring",
 ] }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
+# TLS transport for the HTTP/1 engine (HTTPS). Mirrors the ring-only rustls
+# setup above; `tls12` broadens server compatibility beyond TLS 1.3.
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "ring",
+    "tls12",
+] }
 anyhow = "1"
 pnet = "0.35"
 libc = "0.2"
@@ -68,6 +74,9 @@ dpdk = ["dep:dpdk", "dep:thiserror", "dep:pcap-parser", "dep:etherparse"]
 
 [dev-dependencies]
 criterion = "0.7"
+# Mints throwaway self-signed certs for the HTTPS round-trip test (ring backend
+# to match the crate's rustls setup and avoid the aws-lc-rs C toolchain).
+rcgen = { version = "0.13", default-features = false, features = ["ring", "pem"] }
 
 [[bench]]
 name = "shaper"

--- a/dwd-core/src/engine/http.rs
+++ b/dwd-core/src/engine/http.rs
@@ -5,3 +5,4 @@ mod engine;
 mod engine_raw;
 mod io;
 pub mod payload;
+mod tls;

--- a/dwd-core/src/engine/http/cfg.rs
+++ b/dwd-core/src/engine/http/cfg.rs
@@ -11,8 +11,18 @@ pub struct Config<T> {
     ///
     /// This also limits the maximum concurrent requests in flight. To achieve
     /// better runtime characteristics this value should be the multiple of
-    /// the number of threads.   
+    /// the number of threads.
     pub concurrency: NonZero<usize>,
+    /// Speak HTTPS (TLS) instead of plaintext HTTP.
+    ///
+    /// Certificate verification is disabled, which suits load testing against
+    /// staging hosts and bare IPs. Only honored by the hyper `http` engine.
+    pub tls: bool,
+    /// TLS server name (SNI) presented during the handshake.
+    ///
+    /// Only meaningful with [`tls`](Self::tls). When `None`, the target IP is
+    /// used and the (hostname-only) SNI extension is suppressed.
+    pub server_name: Option<String>,
     /// Native workload settings.
     pub native: NativeLoadConfig,
     /// Request timeout.

--- a/dwd-core/src/engine/http/engine.rs
+++ b/dwd-core/src/engine/http/engine.rs
@@ -20,7 +20,7 @@ use hyper::client::conn::http1::{self, SendRequest};
 use rand::{rngs::ThreadRng, Rng};
 use tokio::net::TcpSocket;
 
-use super::cfg::Config;
+use super::{cfg::Config, tls::Tls};
 use crate::{
     engine::{
         coro::ShapedCoroWorker,
@@ -84,9 +84,19 @@ impl Engine {
         let bind = self.cfg.native.bind_endpoints.clone();
         let data = Arc::new(VecProduce::new(self.cfg.requests.clone()));
 
+        // The TLS config is immutable, so the connector is built once at startup
+        // and cloned across all workers/connections. This keeps the reconnect
+        // path free of TLS/crypto setup allocations (perf contract).
+        let tls = if self.cfg.tls {
+            Some(Tls::new(self.cfg.server_name.as_deref(), self.cfg.addr.ip())?)
+        } else {
+            None
+        };
+
         let thread_pool = ThreadPool::new(num_threads, |tid: usize| {
             let bind = bind.clone();
             let data = data.clone();
+            let tls = tls.clone();
             let requests_per_socket = self.cfg.native.requests_per_socket();
             let requests_per_socket_deviation = self.cfg.native.requests_per_socket_deviation();
             let stat = self.stat.stats[tid].clone();
@@ -105,6 +115,7 @@ impl Engine {
                     self.cfg.addr,
                     bind.clone(),
                     data.clone(),
+                    tls.clone(),
                     requests_per_socket_gen,
                     self.cfg.timeout,
                     self.cfg.tcp_linger,
@@ -164,6 +175,8 @@ struct CoroWorker<B, D> {
     bind: B,
     /// Data to send.
     data: D,
+    /// TLS client, when speaking HTTPS. `None` means plaintext HTTP.
+    tls: Option<Tls>,
     /// Current TCP socket.
     stream: Option<TcpStream>,
     /// The number of requests left for the currently active socket.
@@ -188,6 +201,7 @@ impl<B, D> CoroWorker<B, D> {
         addr: SocketAddr,
         bind: B,
         data: D,
+        tls: Option<Tls>,
         requests_per_sock_gen: RequestsPerSocket,
         timeout: Duration,
         tcp_linger: Option<u64>,
@@ -201,6 +215,7 @@ impl<B, D> CoroWorker<B, D> {
             addr,
             bind,
             data,
+            tls,
             stream: None,
             requests_per_sock_left,
             requests_per_sock_gen,
@@ -315,18 +330,37 @@ where
         }
         self.stat.on_sock_created();
 
-        let io = TokioIo::new(stream);
-        let (sender, conn) = http1::handshake(io).await?;
-        tokio::task::spawn(async move {
-            if let Err(err) = conn.await {
-                log::error!("connection failed: {err}");
-            }
-        });
+        // Optionally negotiate TLS before the HTTP/1 handshake. The two branches
+        // produce different concrete stream types, so each drives the (generic)
+        // handshake itself; both converge on the same transport-agnostic
+        // `SendRequest`.
+        let sender = match &self.tls {
+            Some(tls) => handshake(TokioIo::new(tls.connect(stream).await?)).await?,
+            None => handshake(TokioIo::new(stream)).await?,
+        };
 
         let stream = TcpStream::new(stat, sender);
 
         Ok(stream)
     }
+}
+
+/// Drives the HTTP/1 handshake over `io`, spawning the connection task, and
+/// returns the request sender. Monomorphized over the transport, so it serves
+/// both plaintext TCP and TLS streams.
+#[inline]
+async fn handshake<I>(io: I) -> Result<SendRequest<Empty<Bytes>>, Error>
+where
+    I: hyper::rt::Read + hyper::rt::Write + Unpin + Send + 'static,
+{
+    let (sender, conn) = http1::handshake(io).await?;
+    tokio::task::spawn(async move {
+        if let Err(err) = conn.await {
+            log::error!("connection failed: {err}");
+        }
+    });
+
+    Ok(sender)
 }
 
 impl<B, D> Task for CoroWorker<B, D>

--- a/dwd-core/src/engine/http/engine_raw.rs
+++ b/dwd-core/src/engine/http/engine_raw.rs
@@ -7,7 +7,7 @@ use core::{
 };
 use std::{sync::Arc, time::Instant};
 
-use anyhow::Error;
+use anyhow::{anyhow, Error};
 use bytes::{Bytes, BytesMut};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -72,6 +72,12 @@ impl EngineRaw {
     where
         F: Future<Output = ()> + 'static,
     {
+        if self.cfg.tls {
+            return Err(anyhow!(
+                "TLS (HTTPS) is not supported in http/raw mode; use the `http` mode instead"
+            ));
+        }
+
         let num_threads = self.cfg.native.threads;
 
         let bind = self.cfg.native.bind_endpoints.clone();

--- a/dwd-core/src/engine/http/tls.rs
+++ b/dwd-core/src/engine/http/tls.rs
@@ -1,0 +1,220 @@
+//! TLS support for the HTTP/1 engine (HTTPS).
+//!
+//! Load testing usually targets bare IPs / staging hosts without valid
+//! certificates, so certificate verification is **disabled**: the verifier
+//! below accepts any presented chain. This mirrors the HTTP/3 engine's
+//! [`tls`](crate::engine::http3) behaviour and is deliberate — it must never be
+//! reused in a security context.
+
+use core::net::IpAddr;
+use std::sync::Arc;
+
+use anyhow::Error;
+use rustls::{
+    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    crypto::{ring, verify_tls12_signature, verify_tls13_signature, CryptoProvider},
+    pki_types::{CertificateDer, ServerName, UnixTime},
+    ClientConfig, DigitallySignedStruct, SignatureScheme,
+};
+use tokio::net::TcpStream;
+use tokio_rustls::{client::TlsStream, TlsConnector};
+
+/// ALPN protocol identifier for HTTP/1.1.
+const ALPN_HTTP11: &[u8] = b"http/1.1";
+
+/// A [`ServerCertVerifier`] that accepts any certificate without verification.
+#[derive(Debug)]
+struct NoVerifier(Arc<CryptoProvider>);
+
+impl ServerCertVerifier for NoVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        verify_tls12_signature(message, cert, dss, &self.0.signature_verification_algorithms)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        verify_tls13_signature(message, cert, dss, &self.0.signature_verification_algorithms)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
+    }
+}
+
+/// Builds a rustls [`ClientConfig`] for HTTP/1 that skips certificate
+/// verification and advertises the `http/1.1` ALPN protocol.
+fn insecure_client_config() -> ClientConfig {
+    let provider = Arc::new(ring::default_provider());
+
+    let mut config = ClientConfig::builder_with_provider(provider.clone())
+        .with_safe_default_protocol_versions()
+        .expect("ring provider supports the default TLS versions")
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoVerifier(provider)))
+        .with_no_client_auth();
+
+    config.alpn_protocols = vec![ALPN_HTTP11.to_vec()];
+    config
+}
+
+/// TLS client for the HTTP/1 engine.
+///
+/// Wraps a shared [`TlsConnector`] and the SNI server name presented on every
+/// handshake. Cloning is cheap (the connector is reference-counted internally),
+/// so every worker keeps its own handle.
+#[derive(Clone)]
+pub struct Tls {
+    connector: TlsConnector,
+    server_name: ServerName<'static>,
+}
+
+impl Tls {
+    /// Builds a TLS client. Certificate verification is disabled.
+    ///
+    /// `server_name` sets the SNI hostname; when `None`, the target `ip` is
+    /// used, in which case rustls omits the (hostname-only) SNI extension.
+    pub fn new(server_name: Option<&str>, ip: IpAddr) -> Result<Self, Error> {
+        let server_name = match server_name {
+            Some(name) => ServerName::try_from(name.to_owned())?,
+            None => ServerName::IpAddress(ip.into()),
+        };
+        let connector = TlsConnector::from(Arc::new(insecure_client_config()));
+
+        Ok(Self { connector, server_name })
+    }
+
+    /// Performs the TLS handshake over an already-established TCP stream.
+    #[inline]
+    pub async fn connect(&self, stream: TcpStream) -> Result<TlsStream<TcpStream>, Error> {
+        Ok(self.connector.connect(self.server_name.clone(), stream).await?)
+    }
+}
+
+impl core::fmt::Debug for Tls {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Tls")
+            .field("server_name", &self.server_name)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::net::{IpAddr, Ipv4Addr};
+
+    use super::{insecure_client_config, Tls, ALPN_HTTP11};
+
+    #[test]
+    fn advertises_http11_alpn() {
+        let config = insecure_client_config();
+        assert_eq!(config.alpn_protocols, vec![ALPN_HTTP11.to_vec()]);
+    }
+
+    #[test]
+    fn builds_with_hostname_sni() {
+        Tls::new(Some("example.org"), IpAddr::V4(Ipv4Addr::LOCALHOST)).expect("valid TLS client");
+    }
+
+    #[test]
+    fn builds_with_ip_fallback() {
+        Tls::new(None, IpAddr::V4(Ipv4Addr::LOCALHOST)).expect("valid TLS client");
+    }
+
+    /// Full HTTPS round-trip over the exact transport path the HTTP/1 engine
+    /// uses: [`Tls::connect`] → [`TokioIo`] → hyper `http1` handshake → request.
+    /// The server presents a throwaway self-signed cert; the client accepts it
+    /// because verification is disabled.
+    #[tokio::test]
+    async fn https_round_trip() {
+        use std::sync::Arc;
+
+        use bytes::Bytes;
+        use http::Request;
+        use http_body_util::{BodyExt, Empty};
+        use hyper::client::conn::http1;
+        use rustls::{
+            crypto::ring,
+            pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer},
+            ServerConfig,
+        };
+        use tokio::{
+            io::{AsyncReadExt, AsyncWriteExt},
+            net::{TcpListener, TcpStream},
+        };
+        use tokio_rustls::TlsAcceptor;
+
+        use crate::engine::http::io::TokioIo;
+
+        // Self-signed server identity for 127.0.0.1 / localhost.
+        let certified = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).expect("self-signed cert");
+        let cert = certified.cert.der().clone();
+        let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(certified.key_pair.serialize_der()));
+
+        let server_config = ServerConfig::builder_with_provider(Arc::new(ring::default_provider()))
+            .with_safe_default_protocol_versions()
+            .expect("ring provider supports the default TLS versions")
+            .with_no_client_auth()
+            .with_single_cert(vec![cert], key)
+            .expect("valid server cert");
+        let acceptor = TlsAcceptor::from(Arc::new(server_config));
+
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+
+        // Minimal TLS + HTTP/1.1 origin server: read the request, reply `200 ok`.
+        let server = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.expect("accept");
+            let mut tls = acceptor.accept(tcp).await.expect("tls accept");
+            let mut buf = [0u8; 1024];
+            let _ = tls.read(&mut buf).await.expect("read request");
+            tls.write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\nok")
+                .await
+                .expect("write response");
+            tls.flush().await.expect("flush");
+        });
+
+        // Client: drive the engine's transport path by hand.
+        let tls = Tls::new(None, addr.ip()).expect("tls client");
+        let tcp = TcpStream::connect(addr).await.expect("connect");
+        let stream = tls.connect(tcp).await.expect("tls handshake");
+
+        let (mut sender, conn) = http1::handshake(TokioIo::new(stream)).await.expect("http handshake");
+        tokio::spawn(async move {
+            let _ = conn.await;
+        });
+
+        let req = Request::builder()
+            .uri("/")
+            .header("host", "localhost")
+            .body(Empty::<Bytes>::new())
+            .expect("request");
+        let mut resp = sender.send_request(req).await.expect("send request");
+        assert_eq!(resp.status().as_u16(), 200);
+
+        while let Some(frame) = resp.frame().await {
+            frame.expect("body frame");
+        }
+
+        server.await.expect("server task");
+    }
+}

--- a/dwd-core/src/engine/http3/tls.rs
+++ b/dwd-core/src/engine/http3/tls.rs
@@ -61,8 +61,11 @@ impl ServerCertVerifier for NoVerifier {
 pub fn insecure_client_config() -> ClientConfig {
     let provider = Arc::new(ring::default_provider());
 
+    // QUIC mandates TLS 1.3; pin it explicitly so the config stays valid for
+    // `QuicClientConfig` even when the `tls12` feature is enabled crate-wide
+    // (the HTTP/1 engine turns it on for broader server compatibility).
     let mut config = ClientConfig::builder_with_provider(provider.clone())
-        .with_safe_default_protocol_versions()
+        .with_protocol_versions(&[&rustls::version::TLS13])
         .expect("ring provider supports TLS 1.3")
         .dangerous()
         .with_custom_certificate_verifier(Arc::new(NoVerifier(provider)))

--- a/dwd/src/cmd.rs
+++ b/dwd/src/cmd.rs
@@ -109,6 +109,19 @@ pub struct HttpCmd {
     /// the number of threads.
     #[clap(short, long, default_value_t = std::thread::available_parallelism().unwrap_or(NonZero::<usize>::MIN))]
     pub concurrency: NonZero<usize>,
+    /// Speak HTTPS (TLS) instead of plaintext HTTP.
+    ///
+    /// TLS certificate verification is disabled, which suits load testing
+    /// against staging hosts and bare IPs.
+    #[clap(long)]
+    pub tls: bool,
+    /// TLS server name (SNI) presented during the handshake.
+    ///
+    /// Only takes effect together with `--tls`. Certificate verification is
+    /// disabled, so this only affects the SNI extension the server may route
+    /// on. When omitted, the target IP is used and SNI is suppressed.
+    #[clap(long)]
+    pub server_name: Option<String>,
     /// Path to the JSON payload file.
     #[clap(long, value_name = "PATH")]
     pub payload_json: PathBuf,
@@ -133,6 +146,8 @@ impl HttpCmd {
             addr,
             native,
             concurrency,
+            tls,
+            server_name,
             payload_json,
             timeout,
             tcp_linger,
@@ -145,6 +160,8 @@ impl HttpCmd {
             addr,
             native: native.into_config()?,
             concurrency,
+            tls,
+            server_name,
             timeout: Duration::try_from_secs_f64(timeout)?,
             tcp_linger,
             tcp_no_delay,


### PR DESCRIPTION
## What

Adds HTTPS (TLS) to the hyper `http` engine. Until now the HTTP/1 engine spoke plaintext TCP only; TLS existed solely in the HTTP/3 engine (QUIC mandates it). This mirrors the HTTP/3 TLS pattern for HTTP/1.

- **CLI**: new `--tls` and `--server-name` (SNI) flags on the `http` mode.
- **New `engine/http/tls.rs`**: a rustls client with certificate verification **disabled** (accepts any chain, matching the HTTP/3 engine — suits load testing against staging hosts and bare IPs) and ALPN `http/1.1`. SNI comes from `--server-name`, or the target IP when omitted (which suppresses the hostname-only SNI extension).
- **Engine wiring**: the `Tls` connector is built once at startup and cloned per worker; `reconnect()` optionally performs a TLS handshake before the HTTP/1 handshake, via a monomorphized generic helper so the plaintext path keeps static dispatch and gains no allocation.
- **`http/raw`**: does not support TLS and now rejects `--tls` with a clear error instead of silently sending plaintext.
- **HTTP/3**: client config pinned explicitly to TLS 1.3, because enabling the rustls `tls12` feature (for broader HTTP/1 server compatibility) would otherwise leak TLS 1.2 into the QUIC config via feature unification.
- **Deps**: adds `tokio-rustls` (ring + tls12); `rcgen` as a dev-dependency.
- **README**: documents HTTPS usage.

## Why

A traffic generator needs to hit HTTPS endpoints, not just plaintext HTTP. Verification is intentionally disabled to match the tool's purpose (staging / bare IPs), consistent with the existing HTTP/3 behaviour.

## Testing

- Unit coverage for ALPN and SNI construction.
- A full HTTPS round-trip test exercising the engine's exact transport path (`Tls::connect` → `TokioIo` → hyper `http1` handshake → request → 200) against a real TLS server with a throwaway self-signed cert.
- Local gate green: fmt, clippy (both crates, all-targets), check, test (11 pass), release build.

The binary's TUI could not be exercised in the dev sandbox (PTY allocation is unavailable there), so end-to-end verification is via the in-process test that drives the identical code path.