### PR TITLE
ci: add Ubuntu 18.04 compat DPDK build to CI

### DIFF
--- a/.github/workflows/dpdk.yml
+++ b/.github/workflows/dpdk.yml
@@ -65,3 +65,58 @@ jobs:
           name: dwd-debian-package
           path: dist/*.deb
           if-no-files-found: error
+
+  # Build DPDK-enabled binary for Ubuntu 18.04 (GLIBC 2.27, max compatibility).
+  dpdk-build-compat:
+    name: Build with DPDK 24.11 (Ubuntu 18.04 compat)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image with DPDK (Ubuntu 18.04)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.ubuntu18
+          push: false
+          tags: dwd:dpdk-build-compat
+          load: true
+          cache-from: type=gha,scope=ubuntu18
+          cache-to: type=gha,mode=max,scope=ubuntu18
+
+      - name: Extract artifacts from Docker image
+        run: |
+          # Create container from image.
+          CONTAINER_ID=$(docker create dwd:dpdk-build-compat)
+
+          # Create output directory.
+          mkdir -p dist
+
+          # Copy binary from container.
+          docker cp $CONTAINER_ID:/src/target/release/dwd dist/dwd-dpdk-compat
+
+          # Copy bundled debian package (with rdma-core libs) from /src/dist/.
+          docker cp $CONTAINER_ID:/src/dist/. dist/
+
+          # Cleanup.
+          docker rm $CONTAINER_ID
+
+          # List artifacts.
+          ls -la dist/
+
+      - name: Upload DPDK binary (compat)
+        uses: actions/upload-artifact@v4
+        with:
+          name: dwd-dpdk-linux-x86_64-compat
+          path: dist/dwd-dpdk-compat
+          if-no-files-found: error
+
+      - name: Upload debian package (compat)
+        uses: actions/upload-artifact@v4
+        with:
+          name: dwd-debian-package-compat
+          path: dist/*.deb
+          if-no-files-found: error

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
 
 [[package]]
 name = "dwd"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "dwd-core"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/dpdk/build.rs
+++ b/dpdk/build.rs
@@ -9,7 +9,10 @@ fn main() {
 
     // Path where DPDK 24.11 static libraries are located.
     // Note: DPDK 24.11 installs to lib64 by default, but some distros use lib/x86_64-linux-gnu.
-    const DPDK_LIBRARY_PATHS: &[&str] = &["/usr/local/lib64", "/usr/local/lib/x86_64-linux-gnu"];
+    // Plain /usr/local/lib must be listed explicitly: rdma-core built from source (the
+    // Ubuntu 18.04 compat image) installs there, and rust-lld — the default linker since
+    // Rust 1.90 — does not search it by default, unlike GNU ld.
+    const DPDK_LIBRARY_PATHS: &[&str] = &["/usr/local/lib64", "/usr/local/lib/x86_64-linux-gnu", "/usr/local/lib"];
 
     // DPDK 24.11 core libraries to link with (static).
     const RTE_CORE_LIBS: &[&str] = &[

--- a/dwd-core/Cargo.toml
+++ b/dwd-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwd-core"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.96"
 publish = false

--- a/dwd/Cargo.toml
+++ b/dwd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwd"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.96"
 publish = true


### PR DESCRIPTION
Run the Dockerfile.ubuntu18 (GLIBC 2.27 compat) DPDK build on every push and pull request, not only on release tags. Previously a breakage in the compat toolchain would only surface when cutting a release; now it is caught in CI. The job mirrors release.yml's build-dpdk-compat and shares its GHA cache scope, so release builds also get warm caches.

The very first CI run caught a real breakage: rdma-core built from source installs into /usr/local/lib, which GNU ld searches by default but rust-lld (the default linker since Rust 1.90) does not, so linking failed with 'unable to find library -libverbs / -lmlx5'. Fixed by listing /usr/local/lib explicitly in dpdk/build.rs.

Also bumps the workspace version to 0.7.0 in preparation for the release: since v0.6.1 the gRPC API seam, HTTP/3 support and HTTPS (TLS) support landed, which warrants a minor version bump.