### PR TITLE
feat: add --no-ui flag for headless runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2383,6 +2383,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/README.md
+++ b/README.md
@@ -146,6 +146,17 @@ Here, `macter_lcore` specifies the number of the logical core on which the contr
 
 Packets from a given file are distributed evenly among workers before shooting (the first packet to the first, the second to the second, etc.), and when all the packets are distributed, they will be released in a cycle within their worker.
 
+## Headless mode
+
+By default DWD opens an interactive control UI in the terminal. Passing the global `--no-ui` flag runs it headless: no UI is drawn, the load runs until the profile is exhausted or the process receives `SIGINT` (Ctrl-C) or `SIGTERM`, then shuts down gracefully. This suits scripted runs, CI, containers and remote sessions.
+
+Since there is no UI to type the desired RPS into, drive the load with a profile file (`--generator`), and combine with `--api-addr` to keep observing the generator state and metrics:
+
+```bash
+dwd udp <IP:PORT> --no-ui --generator profile.yaml --api-addr 127.0.0.1:8080
+curl http://127.0.0.1:8080/api/v1/metrics
+```
+
 ## Load profiles
 A load profile is a declarative description of how the load should be generated and for how long.
 

--- a/dwd/Cargo.toml
+++ b/dwd/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { version = "1", features = [
     "macros",
     "sync",
     "io-util",
+    "signal",
 ] }
 clap = { version = "4.5", features = ["derive"] }
 ratatui = "0.29.0"

--- a/dwd/src/cfg.rs
+++ b/dwd/src/cfg.rs
@@ -22,6 +22,8 @@ pub struct Config {
     pub generator_fn: BoxedGeneratorNew,
     /// Address to expose the Prometheus API on.
     pub api_addr: Option<SocketAddr>,
+    /// Run headless, without the interactive TUI.
+    pub no_ui: bool,
 }
 
 impl TryFrom<Cmd> for Config {
@@ -30,6 +32,7 @@ impl TryFrom<Cmd> for Config {
     fn try_from(v: Cmd) -> Result<Self, Self::Error> {
         let mode = v.mode.into_config()?;
         let api_addr = v.api_addr;
+        let no_ui = v.no_ui;
         let generator_fn = {
             let path = v.generator.clone();
 
@@ -46,6 +49,6 @@ impl TryFrom<Cmd> for Config {
             }))
         };
 
-        Ok(Self { mode, generator_fn, api_addr })
+        Ok(Self { mode, generator_fn, api_addr, no_ui })
     }
 }

--- a/dwd/src/cmd.rs
+++ b/dwd/src/cmd.rs
@@ -40,6 +40,13 @@ pub struct Cmd {
     /// to observe the generator state and metrics.
     #[clap(long, global = true, value_name = "IP:PORT")]
     pub api_addr: Option<SocketAddr>,
+    /// Run headless, without the interactive TUI.
+    ///
+    /// The load runs until the profile is exhausted or the process receives
+    /// SIGINT (Ctrl-C) or SIGTERM. Combine with `--api-addr` to keep observing
+    /// the generator state and metrics.
+    #[clap(long, global = true)]
+    pub no_ui: bool,
 }
 
 #[derive(Debug, Clone, Parser)]

--- a/dwd/src/runtime.rs
+++ b/dwd/src/runtime.rs
@@ -5,7 +5,10 @@
 //! (client). The boundary between them is the [`dwd_proto`] gRPC contract: the
 //! TUI never touches the engine directly.
 
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::{
+    future,
+    sync::atomic::{AtomicBool, Ordering},
+};
 use std::{
     sync::Arc,
     thread::{Builder, JoinHandle},
@@ -49,7 +52,8 @@ impl Runtime {
         let snapshot_source = engine.snapshot_source();
         let descriptor = engine.describe().into_response();
 
-        // Start the Prometheus API server if configured (unchanged concern).
+        // Start the Prometheus API server if configured — available both with
+        // the TUI and headless.
         let api_handle = if let Some(addr) = self.cfg.api_addr {
             let metrics_state = Arc::new(dwd_core::api::MetricsState::new(stat_source));
             let server = dwd_core::api::Server::new(addr, metrics_state);
@@ -66,26 +70,39 @@ impl Runtime {
         // handler is now the only writer (the TUI reaches it through the API).
         let (control_tx, control_rx) = mpsc::channel::<dwd_core::GeneratorEvent>(1);
 
-        // Stand up the in-process gRPC server over the core and connect a client
-        // over the same in-memory pipe — no OS socket is opened.
-        let service = DwdService::new(control_tx, snapshot_source, descriptor, self.is_running.clone());
-        let (client_io, server_io) = tokio::io::duplex(DUPLEX_BUFFER);
-        let server_handle = dwd_core::grpc::serve(service, server_io);
-        let grpc_client = client::connect(client_io)?;
+        // The client half of the process exists only when the TUI runs. Headless
+        // (`--no-ui`) there is no client to serve, so the in-process gRPC seam is
+        // not stood up at all, and shutdown comes from process signals instead of
+        // the UI loop.
+        let seam = if self.cfg.no_ui {
+            drop(control_tx);
+            self.spawn_signal_handler();
 
-        // Build the TUI purely as a gRPC client: ask the server which widgets to
-        // render, mirror the streamed stats behind `RemoteStat`, and route key
-        // presses out as control RPCs.
-        let groups = {
-            let mut client = grpc_client.clone();
-            client.describe(DescribeRequest {}).await?.into_inner().groups
+            None
+        } else {
+            // Stand up the in-process gRPC server over the core and connect a client
+            // over the same in-memory pipe — no OS socket is opened.
+            let service = DwdService::new(control_tx, snapshot_source, descriptor, self.is_running.clone());
+            let (client_io, server_io) = tokio::io::duplex(DUPLEX_BUFFER);
+            let server_handle = dwd_core::grpc::serve(service, server_io);
+            let grpc_client = client::connect(client_io)?;
+
+            // Build the TUI purely as a gRPC client: ask the server which widgets to
+            // render, mirror the streamed stats behind `RemoteStat`, and route key
+            // presses out as control RPCs.
+            let groups = {
+                let mut client = grpc_client.clone();
+                client.describe(DescribeRequest {}).await?.into_inner().groups
+            };
+            let remote = Arc::new(client::RemoteStat::new());
+            let (ui_tx, ui_rx) = mpsc::channel::<dwd_core::GeneratorEvent>(1);
+            let ui = client::build_ui(ui_tx, &groups, remote.clone());
+
+            let stats_handle = client::spawn_stats_consumer(grpc_client.clone(), remote);
+            let control_handle = client::spawn_control_forwarder(grpc_client, ui_rx);
+
+            Some((ui, stats_handle, control_handle, server_handle))
         };
-        let remote = Arc::new(client::RemoteStat::new());
-        let (ui_tx, ui_rx) = mpsc::channel::<dwd_core::GeneratorEvent>(1);
-        let ui = client::build_ui(ui_tx, &groups, remote.clone());
-
-        let stats_handle = client::spawn_stats_consumer(grpc_client.clone(), remote);
-        let control_handle = client::spawn_control_forwarder(grpc_client, ui_rx);
 
         let engine = {
             let is_running = self.is_running.clone();
@@ -94,7 +111,12 @@ impl Runtime {
                 .spawn(move || engine.run(is_running))?
         };
 
-        let ui = self.run_ui(ui)?;
+        let ui = match seam {
+            Some((ui, stats_handle, control_handle, server_handle)) => {
+                Some((self.run_ui(ui)?, stats_handle, control_handle, server_handle))
+            }
+            None => None,
+        };
 
         let shaper = engine::run_generator(
             &self.cfg.generator_fn,
@@ -106,18 +128,36 @@ impl Runtime {
         .await;
         shaper?;
 
-        ui.join().expect("no self join").unwrap();
+        if let Some((ui, stats_handle, control_handle, server_handle)) = ui {
+            ui.join().expect("no self join").unwrap();
+
+            // Tear down the gRPC seam when shutting down.
+            stats_handle.abort();
+            control_handle.abort();
+            server_handle.abort();
+        }
         engine.join().expect("no self join")?;
 
-        // Tear down the gRPC seam and the API server when shutting down.
-        stats_handle.abort();
-        control_handle.abort();
-        server_handle.abort();
         if let Some(handle) = api_handle {
             handle.abort();
         }
 
         Ok(())
+    }
+
+    /// Flips `is_running` when the process receives a shutdown signal.
+    ///
+    /// Headless runs have no UI loop to translate key presses into shutdown, so
+    /// SIGINT (Ctrl-C) and SIGTERM take that role instead: the engine and the
+    /// generator loop drain gracefully, exactly as if the TUI had exited.
+    fn spawn_signal_handler(&self) {
+        let is_running = self.is_running.clone();
+
+        tokio::spawn(async move {
+            shutdown_signal().await;
+            log::info!("shutdown signal received, stopping");
+            is_running.store(false, Ordering::SeqCst);
+        });
     }
 
     #[allow(clippy::type_complexity)]
@@ -131,5 +171,40 @@ impl Runtime {
         })?;
 
         Ok(thread)
+    }
+}
+
+/// Completes when SIGINT (Ctrl-C) or SIGTERM is received.
+///
+/// If a handler cannot be installed the corresponding branch pends forever
+/// rather than resolving — the run then ends on profile exhaustion only.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        if let Err(err) = tokio::signal::ctrl_c().await {
+            log::error!("failed to install SIGINT handler: {err}");
+            future::pending::<()>().await;
+        }
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        use tokio::signal::unix::{signal, SignalKind};
+
+        match signal(SignalKind::terminate()) {
+            Ok(mut sigterm) => {
+                sigterm.recv().await;
+            }
+            Err(err) => {
+                log::error!("failed to install SIGTERM handler: {err}");
+                future::pending::<()>().await;
+            }
+        }
+    };
+    #[cfg(not(unix))]
+    let terminate = future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {}
+        _ = terminate => {}
     }
 }


### PR DESCRIPTION
Add a global `--no-ui` flag that runs the generator without the interactive TUI.

In headless mode the in-process gRPC seam (whose only client is the TUI) is not stood up at all, and graceful shutdown is driven by SIGINT (Ctrl-C) or SIGTERM instead of the UI loop: the signal flips `is_running`, draining the engine and the generator loop exactly as if the TUI had exited. The run also ends on load-profile exhaustion, as before.

The Prometheus API server (`--api-addr`) keeps working unchanged, so headless runs remain observable. This suits scripted runs, CI, containers and remote sessions where a terminal UI is unwanted or unavailable.

Verified manually: `dwd udp 127.0.0.1:9 --no-ui --api-addr 127.0.0.1:18099` serves metrics and exits 0 on both SIGINT and SIGTERM; the TUI path is untouched apart from moving into the non-headless branch.